### PR TITLE
Issue fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /replace.yml
+/github-issues-mover

--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ Usage
 Example:
 
 ```sh
+$ touch replace.yml
 $ export SRC_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 $ export DST_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 $ github-issues-mover -src=foo/bar -dst=foo/bar -dst-endpoint=https://ghe.yourhost.com
 ```
+
+The file `replace.yml` must exist (though it can be empty), and configures replacements of imported usernames and issue comment bodies. See `replace.example.yml` for an example.
 
 Contribution
 ------------

--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ Example:
 $ touch replace.yml
 $ export SRC_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 $ export DST_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-$ github-issues-mover -src=foo/bar -dst=foo/bar -dst-endpoint=https://ghe.yourhost.com
+$ github-issues-mover -src=foo/bar -dst=foo/bar -dst-endpoint=https://ghe.yourhost.com -sync
 ```
 
 The file `replace.yml` must exist (though it can be empty), and configures replacements of imported usernames and issue comment bodies. See `replace.example.yml` for an example.
+
+It is highly recommended to use the `-sync` flag when using the issue import API (as is the default). That API is asynchronous, so issue creations are queued in the background on GitHub, and without `-sync` issue number ordering can't be guaranteed.
 
 Contribution
 ------------

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/linyows/ghe-repo-transfer
+module github.com/linyows/github-issues-mover
 
 go 1.13
 
@@ -7,4 +7,5 @@ require (
 	github.com/shurcooL/githubv4 v0.0.0-20200928013246-d292edc3691b
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module github.com/linyows/github-issues-mover
 go 1.13
 
 require (
-	github.com/google/go-github/v32 v32.1.0 // indirect
+	github.com/alecthomas/repr v0.1.1
+	github.com/google/go-github/v32 v32.1.0
 	github.com/shurcooL/githubv4 v0.0.0-20200928013246-d292edc3691b
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58
-	gopkg.in/yaml.v2 v2.2.2 // indirect
+	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/alecthomas/repr v0.1.1 h1:87P60cSmareLAxMc4Hro0r2RBY4ROm0dYwkJNpS4pPs=
+github.com/alecthomas/repr v0.1.1/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -82,7 +84,6 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
 github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
@@ -105,8 +106,10 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -357,6 +360,7 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/issue_import.go
+++ b/issue_import.go
@@ -93,3 +93,19 @@ func CheckImportIssueStatus(client *github.Client, ctx context.Context, owner, r
 	}
 	return i, resp, nil
 }
+
+// GetImportIssueResponse gets an IssueImportResponse from the provided url. In general, this url
+// comes from a previous IssueImportResponse.URL, usually the one returned by ImportIssue.
+func GetImportIssueResponse(client *github.Client, ctx context.Context, url string) (*IssueImportResponse, *github.Response, error) {
+	req, err := client.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Accept", mediaTypeIssueImportAPI)
+	got := new(IssueImportResponse)
+	resp, err := client.Do(ctx, req, got)
+	if err != nil {
+		return nil, resp, err
+	}
+	return got, resp, err
+}

--- a/main.go
+++ b/main.go
@@ -9,10 +9,10 @@ func main() {
 	ctx := context.Background()
 	transfer, err := New(ctx)
 	if err != nil {
-		fmt.Printf("%#v\n", err)
+		fmt.Printf("%v\n", err)
 		return
 	}
 	if err := transfer.Exec(ctx); err != nil {
-		fmt.Printf("%#v\n", err)
+		fmt.Printf("%v\n", err)
 	}
 }

--- a/transfer.go
+++ b/transfer.go
@@ -262,6 +262,9 @@ func (t *Transfer) FetchPulls(ctx context.Context) error {
 		pv["cursor"] = githubv4.NewString(pq.Repository.PullReqeusts.PageInfo.EndCursor)
 	}
 
+	for i := range pulls {
+		pulls[i].Title = "[PR] " + pulls[i].Title
+	}
 	t.Pulls = pulls
 
 	return nil

--- a/transfer.go
+++ b/transfer.go
@@ -341,7 +341,7 @@ func (t *Transfer) DoIssues(ctx context.Context) error {
 	lastNumber := t.Issues[len(t.Issues)-1].Number
 	counter := 0
 
-	for i := 1; i < lastNumber; i++ {
+	for i := 1; i <= lastNumber; i++ {
 		v := t.Issues[counter]
 		if i < v.Number {
 			var err error

--- a/transfer.go
+++ b/transfer.go
@@ -323,6 +323,7 @@ func (t *Transfer) DoMilestones(ctx context.Context) error {
 }
 
 func (t *Transfer) DoIssues(ctx context.Context) error {
+	fmt.Printf("Issues: %+v\n", t.Issues)
 	if len(t.Issues) == 0 {
 		for _, v := range t.Pulls {
 			var err error
@@ -342,7 +343,9 @@ func (t *Transfer) DoIssues(ctx context.Context) error {
 	counter := 0
 
 	for i := 1; i <= lastNumber; i++ {
+		fmt.Printf("Issue %d\n", i)
 		v := t.Issues[counter]
+		fmt.Printf("v# %+v\n", v.Number)
 		if i < v.Number {
 			var err error
 			if t.IsImport {
@@ -451,6 +454,8 @@ func (t *Transfer) buildImportIssueRequest(ctx context.Context, v *Issue) *Issue
 }
 
 func (t *Transfer) importIssue(ctx context.Context, input *IssueImportRequest) error {
+	fmt.Printf("** about to import issue: %+v\n", input)
+	return nil
 	got, _, err := ImportIssue(t.DST.Client, ctx, t.DST.Owner, t.DST.Name, input)
 	if err != nil {
 		return err

--- a/transfer.go
+++ b/transfer.go
@@ -324,22 +324,11 @@ func (t *Transfer) DoMilestones(ctx context.Context) error {
 
 func (t *Transfer) DoIssues(ctx context.Context) error {
 	fmt.Printf("Issues: %+v\n", t.Issues)
-	if len(t.Issues) == 0 {
-		for _, v := range t.Pulls {
-			var err error
-			if t.IsImport {
-				err = t.importIssue(ctx, t.buildImportIssueRequest(ctx, &v))
-			} else {
-				err = t.createIssueWithComments(ctx, t.buildCreateIssueRequest(ctx, &v))
-			}
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	}
 
-	lastNumber := t.Issues[len(t.Issues)-1].Number
+	var lastNumber int
+	if len(t.Issues) > 0 {
+		lastNumber = t.Issues[len(t.Issues)-1].Number
+	}
 	counter := 0
 
 	for i := 1; i <= lastNumber; i++ {
@@ -360,6 +349,21 @@ func (t *Transfer) DoIssues(ctx context.Context) error {
 		}
 		counter++
 
+		var err error
+		if t.IsImport {
+			err = t.importIssue(ctx, t.buildImportIssueRequest(ctx, &v))
+		} else {
+			err = t.createIssueWithComments(ctx, t.buildCreateIssueRequest(ctx, &v))
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, v := range t.Pulls {
+		if v.Number <= lastNumber {
+			continue
+		}
 		var err error
 		if t.IsImport {
 			err = t.importIssue(ctx, t.buildImportIssueRequest(ctx, &v))

--- a/transfer.go
+++ b/transfer.go
@@ -349,23 +349,25 @@ func (t *Transfer) DoIssues(ctx context.Context) error {
 		// Note: in asynchronous mode, it may not be necessary to do this, since
 		// issues could be created out of order.
 		for ; issueNumber < v.Number; issueNumber++ {
-			fmt.Printf("Creating issue #%d - Dummy for alignment\n", issueNumber)
+			fmt.Printf("Creating issue #%d - Dummy for alignment ...", issueNumber)
 			if t.IsImport {
 				err = t.importIssue(ctx, t.buildImportIssueRequest(ctx, nil))
 			} else {
 				err = t.createIssueWithComments(ctx, t.buildCreateIssueRequest(ctx, nil))
 			}
+			fmt.Println()
 			if err != nil {
 				return err
 			}
 		}
 		// Create an issue from a real issue or a pull request
-		fmt.Printf("Creating issue #%d - %s\n", v.Number, v.Title)
+		fmt.Printf("Creating issue #%d - %s ...", v.Number, v.Title)
 		if t.IsImport {
 			err = t.importIssue(ctx, t.buildImportIssueRequest(ctx, &v))
 		} else {
 			err = t.createIssueWithComments(ctx, t.buildCreateIssueRequest(ctx, &v))
 		}
+		fmt.Println()
 		if err != nil {
 			return err
 		}
@@ -463,12 +465,14 @@ func (t *Transfer) importIssue(ctx context.Context, input *IssueImportRequest) e
 	var delayScale = 1.6
 
 	for i := 0; ; i++ {
-		fmt.Printf("| Import status: %s\n", *got.Status) // would be nicer as a horizontal "..."
 		switch *got.Status {
 		case "pending":
+			fmt.Printf(".")
 		case "imported":
+			fmt.Printf(" %s", *got.Status)
 			return nil
 		default:
+			fmt.Printf(" %s", *got.Status)
 			return fmt.Errorf("issue import failed: %s", repr.String(got))
 		}
 		if i >= maxRetries {
@@ -481,7 +485,7 @@ func (t *Transfer) importIssue(ctx context.Context, input *IssueImportRequest) e
 			return err
 		}
 	}
-	return fmt.Errorf("max retries exceeded: %s", repr.String(got))
+	return fmt.Errorf("maximum retries exceeded")
 }
 
 func (t *Transfer) buildCreateDummyIssueRequest(tt *time.Time) *IssueAndCommentsRequest {

--- a/transfer.go
+++ b/transfer.go
@@ -47,6 +47,7 @@ type Transfer struct {
 	SkipMilestones  bool
 	SkipAvatars     bool
 	Sync            bool
+	Debug           bool
 }
 
 type IssueAndCommentsRequest struct {
@@ -65,6 +66,7 @@ func New(ctx context.Context) (*Transfer, error) {
 		skipMilestones = flag.Bool("skip-milestones", false, "skip create milestones")
 		skipAvatars    = flag.Bool("skip-avatars", false, "skip linking avatars")
 		sync           = flag.Bool("sync", false, "create issues synchronously (recommended)")
+		debug          = flag.Bool("debug", false, "debugging output")
 	)
 	flag.Parse()
 
@@ -125,6 +127,7 @@ func New(ctx context.Context) (*Transfer, error) {
 		SkipMilestones:  *skipMilestones,
 		SkipAvatars:     *skipAvatars,
 		Sync:            *sync,
+		Debug:           *debug,
 	}, nil
 }
 
@@ -328,7 +331,9 @@ func (t *Transfer) DoIssues(ctx context.Context) error {
 		return issuesAndPulls[i].Number < issuesAndPulls[j].Number
 	})
 
-	fmt.Printf("Issues and pulls:\n%s\n", repr.String(issuesAndPulls, repr.Indent("  ")))
+	if t.Debug {
+		fmt.Printf("Issues and pulls:\n%s\n\n", repr.String(issuesAndPulls, repr.Indent("  ")))
+	}
 
 	issueNumber := 1
 
@@ -338,7 +343,7 @@ func (t *Transfer) DoIssues(ctx context.Context) error {
 		// Note: in asynchronous mode, it may not be necessary to do this, since
 		// issues could be created out of order.
 		for ; issueNumber < v.Number; issueNumber++ {
-			fmt.Printf("\nCreating issue #%d - Dummy for alignment\n", issueNumber)
+			fmt.Printf("Creating issue #%d - Dummy for alignment\n", issueNumber)
 			if t.IsImport {
 				err = t.importIssue(ctx, t.buildImportIssueRequest(ctx, nil))
 			} else {
@@ -349,7 +354,7 @@ func (t *Transfer) DoIssues(ctx context.Context) error {
 			}
 		}
 		// Create an issue from a real issue or a pull request
-		fmt.Printf("\nCreating issue #%d - %s\n", v.Number, v.Title)
+		fmt.Printf("Creating issue #%d - %s\n", v.Number, v.Title)
 		if t.IsImport {
 			err = t.importIssue(ctx, t.buildImportIssueRequest(ctx, &v))
 		} else {

--- a/transfer.go
+++ b/transfer.go
@@ -76,7 +76,7 @@ func New(ctx context.Context) (*Transfer, error) {
 	srcTc := oauth2.NewClient(ctx, srcTs)
 	srcClient := githubv4.NewClient(srcTc)
 	if defaultEndpoint != *srcEndpoint {
-		srcClient = githubv4.NewEnterpriseClient(*srcEndpoint, srcTc)
+		srcClient = githubv4.NewEnterpriseClient(*srcEndpoint + "/api/graphql", srcTc)
 	}
 
 	dstTs := oauth2.StaticTokenSource(

--- a/transfer.go
+++ b/transfer.go
@@ -48,6 +48,7 @@ type Transfer struct {
 	SkipAvatars     bool
 	Sync            bool
 	Debug           bool
+	DryRun          bool
 }
 
 type IssueAndCommentsRequest struct {
@@ -67,6 +68,7 @@ func New(ctx context.Context) (*Transfer, error) {
 		skipAvatars    = flag.Bool("skip-avatars", false, "skip linking avatars")
 		sync           = flag.Bool("sync", false, "create issues synchronously (recommended)")
 		debug          = flag.Bool("debug", false, "debugging output")
+		dryrun         = flag.Bool("dry-run", false, "make no changes")
 	)
 	flag.Parse()
 
@@ -128,6 +130,7 @@ func New(ctx context.Context) (*Transfer, error) {
 		SkipAvatars:     *skipAvatars,
 		Sync:            *sync,
 		Debug:           *debug,
+		DryRun:          *dryrun,
 	}, nil
 }
 
@@ -434,6 +437,9 @@ func (t *Transfer) buildImportIssueRequest(ctx context.Context, v *Issue) *Issue
 }
 
 func (t *Transfer) importIssue(ctx context.Context, input *IssueImportRequest) error {
+	if t.DryRun {
+		return nil
+	}
 	got, _, err := ImportIssue(t.DST.Client, ctx, t.DST.Owner, t.DST.Name, input)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR improves robustness and adds some quality-of-life features.

- Simplifies the algorithm for interleaving issues and pull requests in order. Fixes a bug where any PRs after the last issue would be omitted.
- Fixes a bug where the last issue might not be imported.
- Adds `-sync` option to create issues synchronously. The GitHub issue import API adds issue creation requests to a job queue which may complete out of order (and could fail later). `-sync` waits for each issue to be imported successfully before requesting a new one, which is much slower but is guaranteed to produce correct results and detect failures.
- Displays progress of issue import visually (with ellipses) in `sync` mode, since each may take a few seconds to import. For example, `Creating issue 3 - My issue ..... imported`.
- Adds `[PR]` to imported pull request titles so they can be easily distinguished from regular issues.
- Appends `/api/graphql` to source GitHub Enterprise endpoint URLs. Unlike `go-github`, which appends `/api/v3` if missing, `githubv4` expects the URL to include the GraphQL endpoint.
- Makes error output more readable in some cases. Improves error handling; for example avoiding a panic when an HTTP error occurs when a `github.ErrorResponse` was expected.
- Adds `-skip-avatars` option. When moving from GHE to GH, links to the old instance are likely to result in broken images.
- Adds a `-dry-run` flag to allow any changes to be previewed.
- Adds a `-debug` flag for debugging output.
- Renames the module to `github-issues-mover`, aligning it with the repo name so it can be installed with `go install`.
- Adds a missing indirect dependency on `yaml.v2`.